### PR TITLE
Update for Ubuntu 22.04.1

### DIFF
--- a/Linux/UbuntuLTS/Ubuntu-LTS-post-install.sh
+++ b/Linux/UbuntuLTS/Ubuntu-LTS-post-install.sh
@@ -177,7 +177,7 @@ adduser "$ENDUSER"
 
 # Set some AppArmor profiles to enforce mode.
 echo -e "${HIGHLIGHT}Configuring apparmor...${NC}"
-aa-enforce /etc/apparmor.d/usr.bin.firefox
+aa-enforce /etc/apparmor.d/usr.bin.firefox || aa-enforce /usr/share/apparmor/extra-profiles/usr.lib.firefox.firefox
 aa-enforce /etc/apparmor.d/usr.sbin.avahi-daemon
 aa-enforce /etc/apparmor.d/usr.sbin.dnsmasq
 aa-enforce /etc/apparmor.d/bin.ping
@@ -332,6 +332,8 @@ chmod a+x /etc/dconf/db
 # Disable apport (error reporting)
 sed -ie '/^enabled=1$/ s/1/0/' /etc/default/apport
 
+# Disable apport pop-up message
+apt-get install -y dbus-x11
 sudo -H -u "$ENDUSER" dbus-launch gsettings set com.ubuntu.update-notifier show-apport-crashes false
 
 # Fix some permissions in /var that are writable and executable by the standard user.


### PR DESCRIPTION
- Added the new location of apparmor configuration for Firefox.
> Now Firefox launches from  /snap/bin/firefox but this seems to me necessary for users who use the [PPA "Mozilla Team"](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa)

- Added the dbus-x11 package which provides dbus-launch, this is necessary for the latest Ubuntu versions.
> See the [list of files in the package](https://packages.ubuntu.com/search?searchon=contents&keywords=dbus-launch&mode=exactfilename&suite=jammy&arch=any). dbus-x11 is a dependency for ubiquity which is uninstalled after the installation of Ubuntu.

Thanks.