### PR TITLE
Refresh Windows 2025 guidance navigation and repository structure

### DIFF
--- a/Microsoft/Windows/README.md
+++ b/Microsoft/Windows/README.md
@@ -7,9 +7,9 @@ Remember, any guidance points given here are recommendations - they are not mand
 
 This configuration was last tested against Windows 10 22H2 in December 2024 and Windows 11 in April 2025.
 
-We recomend you check out the parent page [README](https://github.com/ukncsc/Device-Security-Guidance-Configuration-Packs) before using these guides. The guides listed here are designed for use with Microsoft Intune and can be loaded using the `.json` files in the pack and following the installation instructions linked under the __Supplementary Information__ section of this document.
+We recommend you check out the parent page [README](https://github.com/ukncsc/Device-Security-Guidance-Configuration-Packs) before using these guides. The guides listed here are designed for use with Microsoft Intune and can be loaded using the `.json` files in the pack and following the installation instructions linked under the __Supplementary Information__ section of this document.
 
-The settings we have listed can be viewed reviewed manually inside the [Configurations 2025 (markdown)]() and [Configurations 2025 (csv)]() files.
+The settings we have listed can be reviewed manually in the [Configurations 2025 (markdown)](MDM/Configurations/Configurations%20-%20NCSC%202025.md) and [Configurations 2025 (csv)](MDM/Configurations/Configurations%20-%20NCSC%202025.csv) files.
 
 ## Supplementary Information ##
 

--- a/README.md
+++ b/README.md
@@ -62,17 +62,11 @@ Device-Security-Guidance-Configuration-Packs
 │
 ├───Apple
 │   ├───iOS
-│   │       NCSC_example_iOS_device_configuration.mobileconfig
-│   │       NCSC_example_iOS_VPN_configuration.mobileconfig
-│   │       NCSC_iOS_configurations.csv
-│   │       NCSC_iOS_configurations.md
+│   │       NCSC iOS Example Configurations.mobileconfig
+│   │       NCSC_iOS_Configurations.md
 │   │       README.md
 │   │
 │   └───macOS
-│           macos_provisioning_script.sh
-│           NCSC_example_macOS_VPN_configuration.mobileconfig
-│           NCSC_macOS_configurations.csv
-│           NCSC_macOS_configurations.md
 │           README.md
 │
 ├───Google
@@ -82,7 +76,7 @@ Device-Security-Guidance-Configuration-Packs
 │   │       README.md
 │   │
 │   └───ChromeOS
-│           NCSC_ChromeOS_2025_configuration.csv
+│           NCSC_ChromeOS_2025_configurations.csv
 │           NCSC_ChromeOS_2025_configurations.md
 │           README.md
 │
@@ -91,35 +85,37 @@ Device-Security-Guidance-Configuration-Packs
         │   README.md
         │
         └───MDM
-            └───Configurations
-                │   Configurations_-_NCSC 2025.csv
-                │   Configurations_-_NCSC 2025.md
-                |
-                ├───AppLocker
-                |     AppLocker_appx.xml
-                |     AppLocker_dll.xml
-                |     AppLocker_exe.xml
-                |     AppLocker_msi.xml
-                |     AppLocker_script.xml
-                |
-                ├───DeviceConfiguration
-                |     2025-NCSC-Surface-DFCI.json
-                |
-                ├───EndpointSecurity
-                |     2025-NCSC-Account-Protections.json
-                |     2025-NCSC-Account-Protections_Settings.json
-                |     2025-NCSC-Application-Control.json
-                |     2025-NCSC-Application-Control_Settings.json
-                |
-                └───SettingsCatalog
-                      2025-NCSC-ASR.json
-                      2025-NCSC-App-Control-for-Business.json
-                      2025-NCSC-BitLocker.json
-                      2025-NCSC-Defender-Antivirus.json
-                      2025-NCSC-Defender.json
-                      2025-NCSC-Device-Control.json
-                      2025-NCSC-Edge.json
-                      2025-NCSC-General.json
+  └───Configurations
+      │   Configurations - NCSC 2025.csv
+      │   Configurations - NCSC 2025.md
+      │
+      ├───AppLocker
+      │     AppLocker_appx.xml
+      │     AppLocker_dll.xml
+      │     AppLocker_exe.xml
+      │     AppLocker_msi.xml
+      │     AppLocker_script.xml
+      │     README.md
+      │
+      ├───DeviceConfiguration
+      │     2025-NCSC-Surface-DFCI.json
+      │
+      ├───EndpointSecurity
+      │     2025-NCSC-Account-Protections.json
+      │     2025-NCSC-Account-Protections_Settings.json
+      │     2025-NCSC-Application-Control.json
+      │     2025-NCSC-Application-Control_Settings.json
+      │
+      └───SettingsCatalog
+            2025-NCSC-ASR.json
+            2025-NCSC-App-Control-for-Business.json
+            2025-NCSC-BitLocker.json
+            2025-NCSC-Defender-Antivirus.json
+            2025-NCSC-Defender.json
+            2025-NCSC-Device-Control.json
+            2025-NCSC-Edge.json
+            2025-NCSC-General.json
+            2025-NCSC-Windows-Security-Experience.json
 ```
 
 


### PR DESCRIPTION
## Summary

Refreshes the repository documentation to match the current 2025 configuration pack and restores direct navigation to the Windows policy inventories.

The Windows README currently contains empty links for both 2025 inventory files. The root README's repository tree is also out of sync with `main`: it lists removed Apple files, uses outdated/mistyped ChromeOS and Windows filenames, omits the AppLocker README, and omits the current Windows Security Experience policy.

## Changes

### Windows README
- Link `Configurations 2025 (markdown)` to the current Markdown inventory
- Link `Configurations 2025 (csv)` to the current CSV inventory
- Correct `recomend` to `recommend`
- Simplify the duplicated `viewed reviewed` wording

### Root README
- Refresh the documented repository tree to match current `main`
- Remove Apple files that are no longer present
- Correct the current iOS filenames
- Correct the ChromeOS 2025 CSV filename
- Correct the Windows inventory filenames
- Add the AppLocker README
- Add `2025-NCSC-Windows-Security-Experience.json`

## Validation

- Verified the documented representative paths exist on current `main`
- Verified both Windows inventory targets exist
- Verified no empty Markdown link remains in the Windows README
- No policy values or deployment behaviour are changed
- Branch is based directly on current `main` and contains one documentation commit

This is a documentation follow-up to the Windows refresh/currentness discussion in #27.

Related to #27.
